### PR TITLE
MVNMDVAL-3: <plugin> snippets for pom.xml have wrong indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ It checks the module descriptor template placed in FOLIO modules for issues and 
 Add the following plugin configuration to your project's `pom.xml` file (inside `<build><plugins>` section) to enable validation of the module descriptor during the build process:
 
 ```xml
-<plugin>
-  <groupId>org.folio</groupId>
-  <artifactId>folio-module-descriptor-validator</artifactId>
-  <version>${folio-module-descriptor-validator.version}</version>
-  <executions>
-    <execution>
-      <goals>
-        <goal>validate</goal>
-      </goals>
-    </execution>
-  </executions>
-</plugin>
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 ```
 This is the simplest configuration that will validate the module descriptor during the build process.
 By default, the plugin will fail the build if any issues are detected. Default path to module descriptor: `${project.basedir}/descriptors/ModuleDescriptor-template.json`.
@@ -42,22 +42,22 @@ By default, the plugin will fail the build if any issues are detected. Default p
 To disable the fail-fast mode or add custom path to module descriptor file, add the following configuration:
 
 ```xml
-<plugin>
-  <groupId>org.folio</groupId>
-  <artifactId>folio-module-descriptor-validator</artifactId>
-  <version>${folio-module-descriptor-validator.version}</version>
-  <executions>
-    <execution>
-      <goals>
-        <goal>validate</goal>
-      </goals>
-    </execution>
-  </executions>
-  <configuration>
-    <failOnInvalidDescriptor>false</failOnInvalidDescriptor>
-    <moduleDescriptorFile>${project.basedir}/path/to/module-descriptor.json</moduleDescriptorFile>
-  </configuration>
-</plugin>
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <failOnInvalidDescriptor>false</failOnInvalidDescriptor>
+          <moduleDescriptorFile>${project.basedir}/path/to/module-descriptor.json</moduleDescriptorFile>
+        </configuration>
+      </plugin>
 ```
 ### Non-project usage
 To validate module descriptor without integrating it into the project, you can use the following command:


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MVNMDVAL-3

The `<plugin>` xml snippets for pom.xml have wrong indentation.

The indentation is 0 spaces, but 6 spaces is needed when inserting into `<project><build><plugins>`.

To allow for easy copy and paste regardless of editor capabilities the wrong indentation should be fixed.

## Purpose
Make copy and paste as easy as possible, especially for editors that doesn't automatically indent xml files.

## Approach
Prepend each line with 6 spaces.