### PR TITLE
MVNMDVAL-6 Rename variable / fix typo

### DIFF
--- a/src/main/java/org/folio/md/validator/ModuleDescriptorValidator.java
+++ b/src/main/java/org/folio/md/validator/ModuleDescriptorValidator.java
@@ -27,7 +27,7 @@ public class ModuleDescriptorValidator extends AbstractMojo {
     "${project.basedir}/descriptors/ModuleDescriptor-template.json";
 
   @Parameter(property = "moduleDescriptorFile", defaultValue = DEFAULT_MODULE_DESCRIPTOR_FILE)
-  File moduleDescriptroFile;
+  File moduleDescriptorFile;
 
   @Parameter(property = "failOnInvalidDescriptor", defaultValue = "true")
   boolean failOnInvalidDescriptor;
@@ -37,11 +37,11 @@ public class ModuleDescriptorValidator extends AbstractMojo {
 
   @Override
   public void execute() throws MojoExecutionException {
-    if (moduleDescriptroFile == null || !moduleDescriptroFile.exists()) {
+    if (moduleDescriptorFile == null || !moduleDescriptorFile.exists()) {
       handleFailure("Module descriptor file is not found");
     }
 
-    var moduleDescriptor = parseModuleDescriptorFile(moduleDescriptroFile);
+    var moduleDescriptor = parseModuleDescriptorFile(moduleDescriptorFile);
     if (moduleDescriptor == null) {
       return;
     }

--- a/src/test/java/org/folio/md/validator/ModuleDescriptorValidatorTest.java
+++ b/src/test/java/org/folio/md/validator/ModuleDescriptorValidatorTest.java
@@ -32,7 +32,7 @@ class ModuleDescriptorValidatorTest {
   })
   void execute(String filePath, boolean shouldThrow, String message) {
     mdValidator.failOnInvalidDescriptor = shouldThrow;
-    mdValidator.moduleDescriptroFile = new File(filePath);
+    mdValidator.moduleDescriptorFile = new File(filePath);
 
     if (mdValidator.failOnInvalidDescriptor) {
       assertThatThrownBy(mdValidator::execute)
@@ -46,13 +46,13 @@ class ModuleDescriptorValidatorTest {
   @Test
   void execute_positive() {
     mdValidator.failOnInvalidDescriptor = true;
-    mdValidator.moduleDescriptroFile = new File("src/test/resources/json/valid-md-template.json");
+    mdValidator.moduleDescriptorFile = new File("src/test/resources/json/valid-md-template.json");
 
     assertDoesNotThrow(mdValidator::execute);
   }
 
   private static void cleanProperties(ModuleDescriptorValidator mdValidator) {
-    mdValidator.moduleDescriptroFile = null;
+    mdValidator.moduleDescriptorFile = null;
     mdValidator.failOnInvalidDescriptor = false;
   }
 }


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MVNMDVAL-6

Theres a typo in the variable name for `moduleDescriptorFile` leading to:
```
[WARNING] Parameter 'moduleDescriptorFile' is unknown for plugin 'folio-module-descriptor-validator:1.0.0:validate (default)'
```

## Approach
Rename variable
