### PR TITLE
MVNMDVAL-2: Add report when no issue was found

### DIFF
--- a/src/main/java/org/folio/md/validator/ModuleDescriptorValidator.java
+++ b/src/main/java/org/folio/md/validator/ModuleDescriptorValidator.java
@@ -49,6 +49,8 @@ public class ModuleDescriptorValidator extends AbstractMojo {
     var validated = validator.validate(new ValidationContext(moduleDescriptor));
     if (validated.hasErrorParameters()) {
       handleFailure("Module descriptor not valid: " + asJson(validated.getErrorParameters()));
+    } else {
+      getLog().info("Validated successfully.");
     }
   }
 


### PR DESCRIPTION
A report is missing when folio-module-descriptor-validator doesn’t find any issue.

This is irritating because it indicates that folio-module-descriptor-validator exited unexpectedly without completing the validation.

Example report from maven-checkstyle-plugin:
```
[INFO] --- maven-checkstyle-plugin:3.1.1:check (check) @ okapi-testing ---
[INFO] You have 0 Checkstyle violations.
[INFO]
```

A report similar to "You have 0 Checkstyle violations." is missing in the folio-module-descriptor-validator output.

Solution:

Print "Validated successfully." if there's no violation.

## Purpose
Improve user experience when there are no validation violations. The user should get feedback about this result.

## Approach
Invoke the `getLog()` method to get the `org.apache.maven.plugin.logging.Log` instance of the plugin. Then use the `info` method of that instance and pass a Java String that contains the message to show. Using the `info` method and not the `warn` or `error` method ensures that the output is not flagged as a failure but as an informational message. The passed Java String is "Validated successfully.".