### PR TITLE
MVNMDVAL-8: Add owner exception for mod-pubsub circular dependency

### DIFF
--- a/src/main/java/org/folio/md/validator/service/impl/PermissionDefinitionValidator.java
+++ b/src/main/java/org/folio/md/validator/service/impl/PermissionDefinitionValidator.java
@@ -15,8 +15,21 @@ public class PermissionDefinitionValidator implements Validator {
   }
 
   private static void addErrorParameterIfNotValid(String permission, ValidationContext ctx) {
-    if (!ctx.getDefinedPermissions().contains(permission)) {
-      ctx.addErrorParameter("Permission is not defined in module descriptor", permission);
+    if (ctx.getDefinedPermissions().contains(permission)) {
+      return;
+    }
+    switch (permission) {
+      case "remote-storage.pub-sub-handlers.log-record-event.post":
+      case "audit.pub-sub-handlers.log-record-event.post":
+        // Allow mod-pubsub to define the mod-audit and mod-remote-storage
+        // API endpoint permissions. This solves the circular dependency when assigning permissions
+        // to its system user when enabling the module for a tenant because mod-audit
+        // and mod-remote-storage are not enabled at that time.
+        // We allow this exception because https://github.com/folio-org/mod-pubsub is deprecated
+        // and will be removed soon.
+        return;
+      default:
+        ctx.addErrorParameter("Permission is not defined in module descriptor", permission);
     }
   }
 }

--- a/src/test/java/org/folio/md/validator/service/impl/PermissionDefinitionValidatorTest.java
+++ b/src/test/java/org/folio/md/validator/service/impl/PermissionDefinitionValidatorTest.java
@@ -4,33 +4,22 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.folio.md.validator.support.TestUtils.readModuleDescriptor;
 
 import org.folio.md.validator.model.ValidationContext;
-import org.folio.md.validator.service.Validator;
 import org.folio.md.validator.support.UnitTest;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @UnitTest
 class PermissionDefinitionValidatorTest {
 
-  private final Validator validator = new PermissionDefinitionValidator();
-
-  @Test
-  void validate_positive() {
-    var moduleDescriptor = readModuleDescriptor("json/permission-definition/md-valid.json");
-    var ctx = new ValidationContext(moduleDescriptor);
-
-    validator.validate(ctx);
-
-    assertThat(ctx.getErrorParameters()).isEmpty();
-  }
-
-  @Test
-  void validate_negative_missingPermissionDefinition() {
-    var moduleDescriptor =
-      readModuleDescriptor("json/permission-definition/md-non-valid-missing-permission-definition.json");
-    var ctx = new ValidationContext(moduleDescriptor);
-
-    validator.validate(ctx);
-
-    assertThat(ctx.getErrorParameters()).hasSize(1);
+  @ParameterizedTest
+  @CsvSource(textBlock = """
+      md-valid.json, 0
+      md-mod-pubsub-names.json, 0
+      md-non-valid-missing-permission-definition.json, 1
+      """)
+  void validate(String file, int expectedErrorCount) {
+    var ctx = new ValidationContext(readModuleDescriptor("json/permission-definition/" + file));
+    new PermissionDefinitionValidator().validate(ctx);
+    assertThat(ctx.getErrorParameters()).hasSize(expectedErrorCount);
   }
 }

--- a/src/test/resources/json/permission-definition/md-mod-pubsub-names.json
+++ b/src/test/resources/json/permission-definition/md-mod-pubsub-names.json
@@ -1,0 +1,33 @@
+{
+  "id": "test-module-1.0.0",
+  "name": "test-module",
+  "provides": [
+    {
+      "id": "foo",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [ "GET" ],
+          "pathPattern": "/foo",
+          "permissionsRequired": [ "remote-storage.pub-sub-handlers.log-record-event.post" ]
+        }
+      ]
+    },
+    {
+      "id": "bar",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [ "GET" ],
+          "pathPattern": "/bar",
+          "permissionsRequired": [ "audit.pub-sub-handlers.log-record-event.post" ]
+        }
+      ]
+    }
+  ],
+  "permissionSets": [
+    {
+      "permissionName": "zoo.item.get"
+    }
+  ]
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MVNMDVAL-8

Allow mod-pubsub to define the mod-audit and mod-remote-storage API endpoint permissions. This solves the circular dependency when assigning permissions to its system user when enabling the module for a tenant because mod-audit and mod-remote-storage are not enabled at that time.

We allow this exception because https://github.com/folio-org/mod-pubsub is deprecated and will be removed soon.

## Purpose
Solve circular dependency with mod-pubsub's system user.

## Approach
Allow mod-pubsub to declare the mod-audit and mod-remote-storage API permission.