### PR TITLE
README: Switch from ubuntu-24.04 to ubuntu-latest in GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Modules that don't use maven may use this minimal pom.xml:
   Put this minimal pom.xml file into the directory of the ModuleDescriptor-template.json file.
   Run "mvn compile" to run the validator.
   This is intended for non-maven projects.
-  When running from GitHub Actions use "runs-on: ubuntu-24.04" (or later) for a compatible mvn version.
+  For GitHub Actions use "runs-on: ubuntu-latest" that comes with a compatible mvn version.
   -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>dummy</groupId>


### PR DESCRIPTION
Since 2024-10-30 ubuntu-latest is ubuntu-24.04 and comes with a compatible mvn version: https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/

Before the migration of ubuntu-latest from ubuntu-22.04 to ubunut-24.04 it came with an incompatible mvn version.

## Purpose
Avoid a hard-coded ubuntu version in README.md.

## Approach
Replace ubuntu-24.04 with ubuntu-latest in README.md.